### PR TITLE
PHP7 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Finally add `extension=ed25519.so` to your /etc/php.ini
 Generate 32 secret random bytes from a cryptographically safe source e.g.
 
 ```
+// PHP 7
+$mySecret = random_bytes(32);
+
+// <= PHP 5.6
 $mySecret = openssl_random_pseudo_bytes(32);
+
 ```
 
 Then generate the corresponding 32-byte public key by calling
@@ -40,7 +45,7 @@ $signature = ed25519_sign($message, $mySecret, $myPublic);
 To verify the ```$signature``` for a given ```$message``` against ```$myPublic``` call
 
 ```
-$status = ed25519_sign_open($message,  $myPublic, $signature) );
+$status = ed25519_sign_open($message,  $myPublic, $signature);
 ```
 
 If ```$status === TRUE``` the ```$signature``` is just fine :)
@@ -53,7 +58,7 @@ If ```$status === TRUE``` the ```$signature``` is just fine :)
 $mySecret = openssl_random_pseudo_bytes(32);
 $myPublic = ed25519_publickey($mySecret);
 
-$message = "Hellow World";
+$message = 'Hello, World!';
 
 $signature = ed25519_sign($message, $mySecret, $myPublic);
 var_dump( ed25519_sign_open($message,  $myPublic, $signature) );

--- a/ed25519-ext.c
+++ b/ed25519-ext.c
@@ -4,119 +4,172 @@
 
 #include "php.h"
 #include "ed25519.h"
+#include "ed25519-ext.h"
+#include "ext/standard/info.h"
+#include "zend_exceptions.h"
+#include "ext/spl/spl_exceptions.h"
 
 PHP_FUNCTION(ed25519_publickey)
 {
-	unsigned char *secret;
-	int secret_len;
+	char *secret;
 
-        ed25519_public_key pk;
+#if PHP_VERSION_ID >= 70000
+    size_t secret_len;
+#else
+    int secret_len;
+#endif  
+
+    ed25519_public_key pk;
   
-  
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &secret, &secret_len) == FAILURE) {
-		RETURN_FALSE;
-	}
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &secret, &secret_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(secret, secret_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
 	if (secret_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Secret must be 32 bytes");
-		RETURN_FALSE;
-	}
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Secret must be 32 bytes", 0 TSRMLS_CC);
+    }
 
 	ed25519_publickey(secret, pk);
 
-	RETURN_STRINGL(pk, 32, 1);
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL(pk, 32);
+#else
+    RETURN_STRINGL(pk, 32, 1);
+#endif
 }
 
 PHP_FUNCTION(ed25519_sign_open)
 {
-	unsigned char *m;
-	int m_len;
-	
-	unsigned char *pk;
-	int pk_len;
+	char *m;
+	char *pk;
+	char *rs;
 
-	unsigned char *rs;
-	int rs_len;
-	
+#if PHP_VERSION_ID >= 70000
+    size_t m_len;
+    size_t pk_len;
+    size_t rs_len;
+#else
+    int m_len;
+    int pk_len;
+    int rs_len;
+#endif  
+
 	int result;
 
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &m, &m_len, &pk, &pk_len, &rs, &rs_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(m, m_len)
+        Z_PARAM_STRING(pk, pk_len)
+        Z_PARAM_STRING(rs, rs_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &m, &m_len, &pk, &pk_len, &rs, &rs_len) == FAILURE) {
-		RETURN_FALSE;
-	}
+    if (pk_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Public key must be 32 bytes", 0 TSRMLS_CC);
+    }
 
-	if (pk_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Public key must be 32 bytes");
-		RETURN_FALSE;
-	}
-
-	if (rs_len != 64) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Signature must be 64 bytes");
-		RETURN_FALSE;
-	}
+    if (rs_len != 64) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Signature must be 64 bytes", 0 TSRMLS_CC);
+    }
 
   	result = ed25519_sign_open(m, m_len, pk, rs);
  	if (result == 0) {
-    		RETURN_TRUE;
+		RETURN_TRUE;
   	} else {
-    		RETURN_FALSE;	
+		RETURN_FALSE;	
   	}
 }
 
 PHP_FUNCTION(ed25519_sign)
 {
-	unsigned char *m;
-	int m_len;
-	
-	unsigned char *pk;
-	int pk_len;
+	char *m;
+	char *pk;
+	char *sk;
 
-	unsigned char *sk;
-	int sk_len;
-	
+#if PHP_VERSION_ID >= 70000
+    size_t m_len;
+    size_t pk_len;
+    size_t sk_len;
+#else
+    int m_len;
+    int pk_len;
+    int sk_len;
+#endif  
+
 	ed25519_signature RS;
-	
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &m, &m_len, &sk, &sk_len, &pk, &pk_len) == FAILURE) {
-		RETURN_FALSE;
-	}
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &m, &m_len, &sk, &sk_len, &pk, &pk_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(m, m_len)
+        Z_PARAM_STRING(sk, sk_len)
+        Z_PARAM_STRING(pk, pk_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
-	if (sk_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Secret must be 32 bytes");
-		RETURN_FALSE;
-	}
+    if (sk_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Secret must be 32 bytes", 0 TSRMLS_CC);
+    }
 
-
-        if (pk_len != 32) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING, "Public key must be 32 bytes");
-                RETURN_FALSE;
-        }
+    if (pk_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Public key must be 32 bytes", 0 TSRMLS_CC);
+    }
 
   	ed25519_sign(m, m_len, sk, pk, RS);
   
-  	RETURN_STRINGL(RS, 64, 1);
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL(RS, 64);
+#else
+    RETURN_STRINGL(RS, 64, 1);
+#endif
 }
-
 
 PHP_FUNCTION(curved25519_scalarmult_basepoint)
 {
-        unsigned char *secret;
-        int secret_len;
+    char *secret;
 
-        curved25519_key pk;
+#if PHP_VERSION_ID >= 70000
+    size_t secret_len;
+#else
+    int secret_len;
+#endif  
 
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &secret, &secret_len) == FAILURE) {
-                RETURN_FALSE;
-        }
+    curved25519_key pk;
 
-        if (secret_len != 32) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING, "Secret must be 32 bytes");
-                RETURN_FALSE;
-        }
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &secret, &secret_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(secret, secret_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
-        curved25519_scalarmult_basepoint (pk, secret);
+    if (secret_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Secret must be 32 bytes", 0 TSRMLS_CC);
+    }
 
-        RETURN_STRINGL(pk, 32, 1);
+    curved25519_scalarmult_basepoint(pk, secret);
+
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL(pk, 32);
+#else
+    RETURN_STRINGL(pk, 32, 1);
+#endif
 }
 
 
@@ -137,7 +190,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ed25519_sign, 0, 0, 3)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_curved25519_scalarmult_basepoint, 0, 0, 1)
-        ZEND_ARG_INFO(0, secret)
+    ZEND_ARG_INFO(0, secret)
 ZEND_END_ARG_INFO()
 
 

--- a/ed25519-ext.h
+++ b/ed25519-ext.h
@@ -1,0 +1,4 @@
+extern zend_module_entry ed25519_module_entry;
+
+#define ed25519_module_ptr &ed25519_module_entry
+#define phpext_ed25519_ptr ed25519_module_ptr


### PR DESCRIPTION
Hi,

Thanks for creating this! The following merge request enables PHP7 support for this extension while still maintaining support for PHP 5.6.

```
PHP7 Compatibility

    - Allows compilation on PHP 7, PHP 5.6
    - Adds support to be compiled directly into PHP

 Code improvements

    - Refactoring of PHP7 changes
    - Adding spl_ce_InvalidArgumentException exceptions for invalid parameter types
    - Implementing FAST_ZPP: https://wiki.php.net/rfc/fast_zpp
    - Correcting syntax error in documentation
    - Indicate in README that random_bytes is preferred over openssl_random_pseudo_bytes
```

Please let me know if there are any issues or you'd like to see any additional changes as part of this merge request.
